### PR TITLE
Fix IndexError in create_long_loaddata

### DIFF
--- a/cptools2/loaddata.py
+++ b/cptools2/loaddata.py
@@ -49,7 +49,7 @@ def create_long_loaddata(img_list, is_new_ix=False):
         "Metadata_platename": [_parse.plate_name(i, old_path=old_path) for i in img_list],
         "Metadata_well": [_parse.img_well(i) for i in just_filenames],
         "Metadata_site": [_parse.img_site(i) for i in just_filenames],
-        "Metadata_channel": [_parse.img_channel(i) for i in just_filenames],
+        "Metadata_channel": [_parse.img_channel(i) for i in img_list],
         "Metadata_platenum": [_parse.plate_num(i, old_path=old_path) for i in img_list]
         })
     return df_img


### PR DESCRIPTION
Fixes the parsing of metadata from file names into `Metadata_channel`.

To determine the channel number of an image, parse.img_channel runs the equivalent of:

```python
int(img_url.split('_')[3][1])
```

Before, it was running:

'Some example image_A02_s4BC203976-D332-4A32-A12B-64DEEEBCFBF8.tif' -> `int(img_url.split('_')[3][1])` -> IndexError

The fix uses img_list instead of just_filenames:

'Some batch/2025-03-18/1234/TimePoint_1/Some example image_A02_s4BC203976-D332-4A32-A12B-64DEEEBCFBF8.tif' -> `int(img_url.split('_')[3][1])` -> 4

I was surprised to find this, so this might need a second pair of eyes to make sure this fix is appropriate. My test was done with `new_ix: true` - maybe this needs to be applied only to new-format datasets?
